### PR TITLE
bugfix/accurics_remediation_41509174448164177 - Auto Generated Pull Request From Accurics

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,11 @@ resource "aws_instance" "this" {
     volume_size = 1000
     iops        = 800
   }
+
+  metadata_options {
+    http_endpoint = "disabled"
+    http_tokens   = "required"
+  }
 }
 
 resource "aws_lambda_function" "this" {


### PR DESCRIPTION
In AWS Console - 
1. When launching a new instance in the Amazon EC2 console, select the following options on the Configure Instance Details page:
    a. Under Advanced Details, for Metadata accessible, select Enabled.
    b. For Metadata version, select V2.

In Terraform -
1. For the aws_instance resource, set the metadata_options.http_endpoint field to disabled.
2. Set the metadata_options.http_tokens field to required.

References:
[https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/configuring-instance-metadata-service.html](https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/configuring-instance-metadata-service.html)
[https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/instance#metadata_options](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/instance#metadata_options)